### PR TITLE
fix libsbml.bib

### DIFF
--- a/site/content/software/libsbml/libsbml.bib
+++ b/site/content/software/libsbml/libsbml.bib
@@ -4,11 +4,11 @@
   journal = {Bioinformatics},
   year = {2008},
   volume = {24},
-  number = {6}
+  number = {6},
   pages = {880--881},
   issn = {1367-4803},
   doi = {10.1093/bioinformatics/btn051},
-  url = {http://dx.doi.org/10.1093/bioinformatics/btn051},
+  url = {http://dx.doi.org/10.1093/bioinformatics/btn051}
 }
 
 


### PR DESCRIPTION
commas in wrong place, BibDesk.app on macos cannot open